### PR TITLE
Add DummyThreads as an alternative `AbstractSlackThread`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlackThreads"
 uuid = "a271ce43-5be6-465b-b549-2328063b090f"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ julia> thread("Update", "plot1.png" => scatter(rand(10), rand(10)),
                         "plot2.png" => lines(rand(10)));
 ```
 
+One may use `thread = DummyThread()` to instead store messages without
+sending them to Slack.
+
 ## Exceptions
 
 SlackThreads does not throw any exceptions when:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ julia> thread("Update", "plot1.png" => scatter(rand(10), rand(10)),
 ```
 
 One may use `thread = DummyThread()` to instead store messages without
-sending them to Slack.
+sending them to Slack. See the docstring for more details.
 
 ## Exceptions
 

--- a/src/SlackThreads.jl
+++ b/src/SlackThreads.jl
@@ -14,7 +14,7 @@ mutable struct SlackThread <: AbstractSlackThread
     ts::Union{String,Nothing} # In Slack terminology, `ts_thread`: the ID of another un-threaded message to reply to (https://api.slack.com/reference/messaging/payload)
 end
 
-function Base.copyto!(thread::SlackThread, obj)
+function Base.copyto!(thread::AbstractSlackThread, obj)
     thread.channel = obj.channel
     thread.ts = obj.ts
     return thread

--- a/src/SlackThreads.jl
+++ b/src/SlackThreads.jl
@@ -15,7 +15,7 @@ mutable struct SlackThread <: AbstractSlackThread
     ts::Union{String,Nothing} # In Slack terminology, `ts_thread`: the ID of another un-threaded message to reply to (https://api.slack.com/reference/messaging/payload)
 end
 
-function Base.copyto!(thread::AbstractSlackThread, obj)
+function Base.copyto!(thread::SlackThread, obj)
     thread.channel = obj.channel
     thread.ts = obj.ts
     return thread

--- a/src/SlackThreads.jl
+++ b/src/SlackThreads.jl
@@ -73,8 +73,8 @@ function format_slack_link(uri, msg=nothing)
 end
 
 """
-    (thread::AbstractSlackThread)(text::AbstractString, uploads...;
-                                  combine_texts=combine_texts)
+    (thread::SlackThread)(text::AbstractString, uploads...;
+                          combine_texts=combine_texts)
 
 Sends a message to the Slack thread with the contents `text`. If this is the
 first message sent by `thread`, this starts a new thread (in `thread.channel`),
@@ -123,7 +123,7 @@ One may pass any function to the `combine_texts` keyword argument which accepts 
 for example, `texts -> SlackThreads.combine_texts(texts; max_length=100, message_count_suffix=(i, n) -> "")`
 to split messages after 100 characters, and to not add a `[\$i / \$n]` suffix to the messages.
 """
-function (thread::AbstractSlackThread)(text::AbstractString, uploads...;
+function (thread::SlackThread)(text::AbstractString, uploads...;
                                combine_texts=combine_texts)
     return @maybecatch begin
         if thread.channel === nothing
@@ -144,13 +144,13 @@ function (thread::AbstractSlackThread)(text::AbstractString, uploads...;
                 # to the general case.
                 extra_args = ["-F", "initial_comment=$(text)", "-F",
                               "channels=$(thread.channel)", "-F", "thread_ts=$(thread.ts)"]
-                return upload_file(thread, local_file(only(uploads); dir); extra_args)
+                return upload_file(local_file(only(uploads); dir); extra_args)
             end
 
             texts = String[text]
 
             for item in uploads
-                r = upload_file(thread, local_file(item; dir))
+                r = upload_file(local_file(item; dir))
                 r === nothing && continue
                 push!(texts, format_slack_link(r.file.permalink, " "))
             end

--- a/src/SlackThreads.jl
+++ b/src/SlackThreads.jl
@@ -5,7 +5,8 @@ using StructTypes
 using FileIO
 using Mocking
 
-export AbstractSlackThread, SlackThread, DummyThread, slack_log_exception
+export AbstractSlackThread, SlackThread, slack_log_exception
+export DummyThread, SlackCallRecord
 
 abstract type AbstractSlackThread end
 

--- a/src/dummy_slack_thread.jl
+++ b/src/dummy_slack_thread.jl
@@ -1,20 +1,19 @@
 mutable struct DummyThread <: AbstractSlackThread
     channel::Union{String,Nothing}
     ts::Union{String,Nothing}
-    messages::Vector{String}
-    files::Vector{Tuple{String, Vector{String}}}
+    logged::Vector{Any}
 end
 
-DummyThread() = DummyThread(nothing, nothing, String[], Tuple{String, Vector{String}}[])
+DummyThread() = DummyThread(nothing, nothing, [])
 
 StructTypes.StructType(::DummyThread) = StructTypes.Struct()
 
-function send_message(d::DummyThread, msg)
-    push!(d.messages, msg)
+function (d::DummyThread)(args...)
+    push!(d.logged, args)
     return nothing
 end
 
-function upload_file(d::DummyThread, file; extra_args=String[])
-    push!(d.files, (file, extra_args))
+function send_exception_message(d::DummyThread, msg)
+    push!(d.logged, tuple(msg))
     return nothing
 end

--- a/src/dummy_slack_thread.jl
+++ b/src/dummy_slack_thread.jl
@@ -1,3 +1,15 @@
+"""
+    DummyThread <: AbstractSlackThread
+
+Provides a "dummy" SlackThread which does not make any API calls
+to Slack, and instead logs messages to it's `logged` field.
+
+This can be used for testing or to pass to code expecting an `AbstractSlackThread`
+when you don't want to log anything to Slack.
+
+The `logged` field is a `Vector{Any}` such that each element is a tuple whose first entry
+is a text message, and the following entries correspond to attachments.
+"""
 mutable struct DummyThread <: AbstractSlackThread
     channel::Union{String,Nothing}
     ts::Union{String,Nothing}

--- a/src/dummy_slack_thread.jl
+++ b/src/dummy_slack_thread.jl
@@ -15,6 +15,11 @@ struct SlackCallRecord
     kwargs::NamedTuple
 end
 
+StructTypes.StructType(::Type{SlackCallRecord}) = StructTypes.Struct()
+# This makes it so JSON3 doesn't omit tuples/namedtuples if they are empty
+@inline StructTypes.isempty(::Type{SlackCallRecord}, ::NamedTuple) = false
+@inline StructTypes.isempty(::Type{SlackCallRecord}, ::Tuple) = false
+
 """
     DummyThread <: AbstractSlackThread
 
@@ -36,7 +41,7 @@ end
 
 DummyThread() = DummyThread(nothing, nothing, [])
 
-StructTypes.StructType(::DummyThread) = StructTypes.Struct()
+StructTypes.StructType(::Type{DummyThread}) = StructTypes.Struct()
 
 function (d::DummyThread)(args...; kwargs...)
     push!(d.logged, SlackCallRecord(:DummyThread, args, NamedTuple(kwargs)))

--- a/src/dummy_slack_thread.jl
+++ b/src/dummy_slack_thread.jl
@@ -1,0 +1,20 @@
+mutable struct DummyThread <: AbstractSlackThread
+    channel::Union{String,Nothing}
+    ts::Union{String,Nothing}
+    messages::Vector{String}
+    files::Vector{Tuple{String, Vector{String}}}
+end
+
+DummyThread() = DummyThread(nothing, nothing, String[], Tuple{String, Vector{String}}[])
+
+StructTypes.StructType(::DummyThread) = StructTypes.Struct()
+
+function send_message(d::DummyThread, msg)
+    push!(d.messages, msg)
+    return nothing
+end
+
+function upload_file(d::DummyThread, file; extra_args=String[])
+    push!(d.files, (file, extra_args))
+    return nothing
+end

--- a/src/slack_api.jl
+++ b/src/slack_api.jl
@@ -37,7 +37,7 @@ function local_file(name, object; dir=mktempdir())
     return local_path
 end
 
-function upload_file(local_path::AbstractString; extra_args=String[])
+function upload_file(::SlackThread, local_path::AbstractString; extra_args=String[])
     api = "https://slack.com/api/files.upload"
 
     token = get(ENV, "SLACK_TOKEN", nothing)

--- a/src/slack_api.jl
+++ b/src/slack_api.jl
@@ -37,7 +37,7 @@ function local_file(name, object; dir=mktempdir())
     return local_path
 end
 
-function upload_file(::SlackThread, local_path::AbstractString; extra_args=String[])
+function upload_file(local_path::AbstractString; extra_args=String[])
     api = "https://slack.com/api/files.upload"
 
     token = get(ENV, "SLACK_TOKEN", nothing)

--- a/src/slack_log_exception.jl
+++ b/src/slack_log_exception.jl
@@ -13,13 +13,13 @@ default_exception_text(exception, backtrace) = """
             """
 
 """
-    slack_log_exception(f, thread::SlackThread; interrupt_text=DEFAULT_INTERRUPT_TEXT,
+    slack_log_exception(f, thread::AbstractSlackThread; interrupt_text=DEFAULT_INTERRUPT_TEXT,
                         exception_text=default_exception_text)
-    slack_log_exception(thread::SlackThread, exception, backtrace;
+    slack_log_exception(thread::AbstractSlackThread, exception, backtrace;
                         interrupt_text=DEFAULT_INTERRUPT_TEXT,
                         exception_text=default_exception_text)
 
-Log an exception (and stacktrace) to a `SlackThread`. Can be used with a zero-argument
+Log an exception (and stacktrace) to a `AbstractSlackThread`. Can be used with a zero-argument
 function `f`, as in
 
 ```julia
@@ -43,7 +43,7 @@ end
 * Pass `interrupt_text::AbstractString` to customize the message sent when an `InterruptException` is caught. See `SlackThreads.DEFAULT_INTERRUPT_TEXT` for the default text.
 * Pass a two-argument function `exception_text` to customize the message shown for a general exception, where the arguments are `exception` and `backtrace`.
 """
-function slack_log_exception(f, thread::SlackThread; interrupt_text=DEFAULT_INTERRUPT_TEXT,
+function slack_log_exception(f, thread::AbstractSlackThread; interrupt_text=DEFAULT_INTERRUPT_TEXT,
                              exception_text=default_exception_text)
     try
         f()
@@ -54,7 +54,7 @@ function slack_log_exception(f, thread::SlackThread; interrupt_text=DEFAULT_INTE
     end
 end
 
-function slack_log_exception(thread::SlackThread, exception, backtrace;
+function slack_log_exception(thread::AbstractSlackThread, exception, backtrace;
                              interrupt_text=DEFAULT_INTERRUPT_TEXT,
                              exception_text=default_exception_text)
     @maybecatch begin

--- a/src/slack_log_exception.jl
+++ b/src/slack_log_exception.jl
@@ -45,7 +45,8 @@ end
 * Pass `interrupt_text::AbstractString` to customize the message sent when an `InterruptException` is caught. See `SlackThreads.DEFAULT_INTERRUPT_TEXT` for the default text.
 * Pass a two-argument function `exception_text` to customize the message shown for a general exception, where the arguments are `exception` and `backtrace`.
 """
-function slack_log_exception(f, thread::AbstractSlackThread; interrupt_text=DEFAULT_INTERRUPT_TEXT,
+function slack_log_exception(f, thread::AbstractSlackThread;
+                             interrupt_text=DEFAULT_INTERRUPT_TEXT,
                              exception_text=default_exception_text)
     try
         f()
@@ -62,7 +63,7 @@ function slack_log_exception(thread::AbstractSlackThread, exception, backtrace;
     @maybecatch begin
         msg = exception isa InterruptException ? interrupt_text :
               exception_text(exception, backtrace)
-            send_exception_message(thread, msg)
+        send_exception_message(thread, msg)
     end "Error when logging exception to Slack."
     return nothing
 end

--- a/src/slack_log_exception.jl
+++ b/src/slack_log_exception.jl
@@ -60,7 +60,9 @@ function slack_log_exception(thread::AbstractSlackThread, exception, backtrace;
     @maybecatch begin
         msg = exception isa InterruptException ? interrupt_text :
               exception_text(exception, backtrace)
-        send_message(thread, msg)
+            send_exception_message(thread, msg)
     end "Error when logging exception to Slack."
     return nothing
 end
+
+send_exception_message(thread::SlackThread, msg) = send_message(thread, msg)

--- a/src/slack_log_exception.jl
+++ b/src/slack_log_exception.jl
@@ -19,7 +19,9 @@ default_exception_text(exception, backtrace) = """
                         interrupt_text=DEFAULT_INTERRUPT_TEXT,
                         exception_text=default_exception_text)
 
-Log an exception (and stacktrace) to a `AbstractSlackThread`. Can be used with a zero-argument
+Log an exception (and stacktrace) to a `AbstractSlackThread` by constructing
+a textual message and passing it to the `thread` with
+`SlackThreads.send_exception_message`. Can be used with a zero-argument
 function `f`, as in
 
 ```julia

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,7 +240,6 @@ end
         @test d.logged[4].kwargs == (; unfurl_media = true)
     end
 
-    # @testset "$ThreadType" for ThreadType in (SlackThread, DummyThread)
     # Now we test with `SlackThreads.CATCH_EXCEPTIONS[] = false`, i.e.
     # with throwing exceptions. This option exists only for testing, really.
     # The point is we don't want our tests to "pass" while logging exceptions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,6 +239,14 @@ end
         @test d.logged[4].call == :DummyThread
         @test d.logged[4].args == tuple("bye")
         @test d.logged[4].kwargs == (; unfurl_media=true)
+
+        # (de)-Serialization
+        roundtrip = JSON3.read(JSON3.write(d), DummyThread)
+        @test roundtrip.logged[1] == d.logged[1]
+        @test roundtrip.logged[2].kwargs == d.logged[2].kwargs
+        # for some reason, JSON3 deserializes a Pair to a Dict (which is a collection of Pairs)
+        @test only(roundtrip.logged[2].args[2]) == d.logged[2].args[2]
+        @test roundtrip.logged[3] == d.logged[3]
     end
 
     # Now we test with `SlackThreads.CATCH_EXCEPTIONS[] = false`, i.e.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,6 +206,16 @@ end
         @test messages == ["a1/1"]
     end
 
+    @testset "DummyThreads" begin
+        d = DummyThread()
+
+        d("hi")
+        @test d.logged[1] = tuple("hi")
+        d("hi", "a" => "b")
+        @test d.logged[2] = tuple("hi", "a" => "b")
+
+    end
+
     # Now we test with `SlackThreads.CATCH_EXCEPTIONS[] = false`, i.e.
     # with throwing exceptions. This option exists only for testing, really.
     # The point is we don't want our tests to "pass" while logging exceptions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -220,15 +220,19 @@ end
         JET_tests(DummyThread)
         d = DummyThread()
         d("hi")
-        @test d.logged[1] == tuple("hi")
+        @test d.logged[1] isa SlackCallRecord
+        @test d.logged[1].args == tuple("hi")
+        @test d.logged[1].call == :DummyThread
+        @test isempty(d.logged[1].kwargs)
         d("hi", "a" => "b")
-        @test d.logged[2] == ("hi", "a" => "b")
+        @test d.logged[2].args == ("hi", "a" => "b")
         try
         slack_log_exception(d) do
             sqrt(-1)
         end
         catch DomainError end
-        @test contains(d.logged[3][1], ":alert: Error occured! :alert:")
+        @test contains(d.logged[3].args[1], ":alert: Error occured! :alert:")
+        @test d.logged[3].call == :send_exception_message
     end
 
     # @testset "$ThreadType" for ThreadType in (SlackThread, DummyThread)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,17 +227,18 @@ end
         d("hi", "a" => "b")
         @test d.logged[2].args == ("hi", "a" => "b")
         try
-        slack_log_exception(d) do
-            sqrt(-1)
+            slack_log_exception(d) do
+                return sqrt(-1)
+            end
+        catch DomainError
         end
-        catch DomainError end
         @test contains(d.logged[3].args[1], ":alert: Error occured! :alert:")
         @test d.logged[3].call == :send_exception_message
 
-        d("bye"; unfurl_media = true)
+        d("bye"; unfurl_media=true)
         @test d.logged[4].call == :DummyThread
         @test d.logged[4].args == tuple("bye")
-        @test d.logged[4].kwargs == (; unfurl_media = true)
+        @test d.logged[4].kwargs == (; unfurl_media=true)
     end
 
     # Now we test with `SlackThreads.CATCH_EXCEPTIONS[] = false`, i.e.
@@ -270,16 +271,16 @@ end
                         @test thread.ts == "abc"
 
                         @test thread("hi again", "file.txt" => "this is a string").ok ==
-                            true
+                              true
 
                         # We didn't pass a `file` back in our reply
                         @test_throws KeyError thread("hi again",
-                                                    "file.txt" => "this is a string",
-                                                    "file2.txt" => "abc")
+                                                     "file.txt" => "this is a string",
+                                                     "file2.txt" => "abc")
                     end
 
                     Mocking.apply(readchomp_reply_patch(Dict("ok" => false,
-                                                            "error" => "no"))) do
+                                                             "error" => "no"))) do
                         @test_throws SlackThreads.SlackError("no") thread("bye")
                     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,6 +240,15 @@ end
         @test d.logged[4].args == tuple("bye")
         @test d.logged[4].kwargs == (; unfurl_media=true)
 
+        # Properties
+        @test propertynames(d) == (:channel, :ts, :logged)
+        d.channel = "hi" # no error
+        d.ts = "bye" # no error
+        @test_throws MethodError d.channel = 1
+        @test_throws MethodError d.ts = 1
+        @test d.channel === nothing
+        @test d.ts === nothing
+
         # (de)-Serialization
         roundtrip = JSON3.read(JSON3.write(d), DummyThread)
         @test roundtrip.logged[1] == d.logged[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -233,6 +233,11 @@ end
         catch DomainError end
         @test contains(d.logged[3].args[1], ":alert: Error occured! :alert:")
         @test d.logged[3].call == :send_exception_message
+
+        d("bye"; unfurl_media = true)
+        @test d.logged[4].call == :DummyThread
+        @test d.logged[4].args == tuple("bye")
+        @test d.logged[4].kwargs == (; unfurl_media = true)
     end
 
     # @testset "$ThreadType" for ThreadType in (SlackThread, DummyThread)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,6 +244,7 @@ end
         @test propertynames(d) == (:channel, :ts, :logged)
         d.channel = "hi" # no error
         d.ts = "bye" # no error
+        @test_throws ErrorException("type DummyThread has no field xyz") d.xyz
         @test_throws MethodError d.channel = 1
         @test_throws MethodError d.ts = 1
         @test d.channel === nothing


### PR DESCRIPTION
Closes https://github.com/beacon-biosignals/SlackThreads.jl/issues/14 and provides one option for handling https://github.com/beacon-biosignals/SlackThreads.jl/issues/7
