### PR TITLE
use curl_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlackThreads"
 uuid = "a271ce43-5be6-465b-b549-2328063b090f"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 CURL_jll = "b21e61f3-bafc-59ac-ab14-4c5c62d6588d"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Beacon Biosignals, Inc."]
 version = "0.1.4"
 
 [deps]
+CURL_jll = "b21e61f3-bafc-59ac-ab14-4c5c62d6588d"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
@@ -11,6 +12,7 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
 Aqua = "0.5"
+CURL_jll = "7.81.0"
 FileIO = "1.11"
 JSON3 = "1.9"
 Mocking = "0.7"

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ has access, get the channel ID (a value like `C1H9RESGL` which you can find at
 the bottom of the "About" section of a channel). You can pass this to the
 `SlackThread` constructor or set an environmental variable `SLACK_CHANNEL`.
 
-### 3. `curl` binary
-
-Currently, this package assumes you have a `curl` binary installed and on your
-PATH. Hopefully this requirement can be lifted soon with the help of Yggdrasil
-(see [Yggdrasil#2720](https://github.com/JuliaPackaging/Yggdrasil/issues/2720)).
-
 ## Usage
 
 The main object of interest is a `SlackThread`, constructed by `thread =

--- a/src/SlackThreads.jl
+++ b/src/SlackThreads.jl
@@ -5,6 +5,8 @@ using StructTypes
 using FileIO
 using Mocking
 
+using CURL_jll
+
 export AbstractSlackThread, SlackThread, slack_log_exception
 export DummyThread, SlackCallRecord
 

--- a/src/slack_api.jl
+++ b/src/slack_api.jl
@@ -51,7 +51,7 @@ function upload_file(local_path::AbstractString; extra_args=String[])
     auth = "Authorization: Bearer $(token)"
 
     response = @maybecatch begin
-        JSON3.read(@mock readchomp(`curl -s -F file=@$(local_path) $(extra_args) -H $auth $api`))
+        JSON3.read(@mock readchomp(`$(curl()) -s -F file=@$(local_path) $(extra_args) -H $auth $api`))
     end "Error when attempting to upload file to Slack"
 
     response === nothing && return nothing
@@ -95,7 +95,7 @@ function send_message(thread::SlackThread, text::AbstractString; options...)
     auth = "Authorization: Bearer $(token)"
 
     response = @maybecatch begin
-        JSON3.read(@mock readchomp(`curl -s -X POST -H $auth -H 'Content-type: application/json; charset=utf-8' --data $(data_str) $api`))
+        JSON3.read(@mock readchomp(`$(curl()) -s -X POST -H $auth -H 'Content-type: application/json; charset=utf-8' --data $(data_str) $api`))
     end "Error when attempting to send message to Slack thread"
 
     response === nothing && return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using CairoMakie
 using Logging
 using Aqua
 
+using CURL_jll
+
 Mocking.activate()
 
 const OK_REPLY = Dict("ok" => true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,7 +84,7 @@ function tests_without_errors()
             # Currently, this is the only test that checks that the requests we are making
             # are reasonable; we could emit nonsense and all the other tests would pass!
             @test cmd ==
-                  `curl -s -X POST -H 'Authorization: Bearer hi' -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"bye","thread_ts":"abc","text":"hi"}' https://slack.com/api/chat.postMessage`
+                  `$(curl()) -s -X POST -H 'Authorization: Bearer hi' -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"bye","thread_ts":"abc","text":"hi"}' https://slack.com/api/chat.postMessage`
         end
 
         Mocking.apply(hi_patch) do
@@ -94,7 +94,7 @@ function tests_without_errors()
         option_patch = readchomp_input_patch() do cmd
             # Another reference test
             @test cmd ==
-                  `curl -s -X POST -H 'Authorization: Bearer hi' -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"bye","thread_ts":"abc","link_names":true,"text":"hi"}' https://slack.com/api/chat.postMessage`
+                  `$(curl()) -s -X POST -H 'Authorization: Bearer hi' -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"bye","thread_ts":"abc","link_names":true,"text":"hi"}' https://slack.com/api/chat.postMessage`
         end
 
         Mocking.apply(option_patch) do


### PR DESCRIPTION
Removes need for system CURL.  tests pass locally, but I see that we're not actually making any API requests in the tests so I'll hvae to find a way to test this manually to be confident that it actually works...