### PR TITLE
use HTTP.jl in place of system `curl`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         version:
           - "1.6"
-          - "1.7"
+          - "1"
           - "nightly"
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlackThreads"
 uuid = "a271ce43-5be6-465b-b549-2328063b090f"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.4"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
@@ -12,6 +13,7 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 [compat]
 Aqua = "0.5"
 FileIO = "1.11"
+HTTP = "1"
 JSON3 = "1.9"
 Mocking = "0.7"
 StructTypes = "1.8"

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ has access, get the channel ID (a value like `C1H9RESGL` which you can find at
 the bottom of the "About" section of a channel). You can pass this to the
 `SlackThread` constructor or set an environmental variable `SLACK_CHANNEL`.
 
-### 3. `curl` binary
-
-Currently, this package assumes you have a `curl` binary installed and on your
-PATH. Hopefully this requirement can be lifted soon with the help of Yggdrasil
-(see [Yggdrasil#2720](https://github.com/JuliaPackaging/Yggdrasil/issues/2720)).
-
 ## Usage
 
 The main object of interest is a `SlackThread`, constructed by `thread =

--- a/format/run.jl
+++ b/format/run.jl
@@ -5,7 +5,7 @@ function main()
     # note: keep in sync with `.github/workflows/format-check.yml`
     for d in ["src/", "test/"]
         @info "...linting $d ..."
-        dir_perfect = format(d; style=YASStyle())
+        dir_perfect = format(d; style=YASStyle(), join_lines_based_on_source=true)
         perfect = perfect && dir_perfect
     end
     if perfect

--- a/src/SlackThreads.jl
+++ b/src/SlackThreads.jl
@@ -151,9 +151,10 @@ function (thread::SlackThread)(text::AbstractString, uploads...;
                 # to thread from it. So in that case, we fallback
                 # to the general case. We also can't do this if the user has passed
                 # any options, since those are likely only valid for `chat.postMessage`.
-                extra_args = ["-F", "initial_comment=$(text)", "-F",
-                              "channels=$(thread.channel)", "-F", "thread_ts=$(thread.ts)"]
-                return upload_file(local_file(only(uploads); dir); extra_args)
+                extra_body = ["initial_comment" => text,
+                              "channels" => thread.channel,
+                              "thread_ts" => thread.ts]
+                return upload_file(local_file(only(uploads); dir); extra_body)
             end
 
             texts = String[text]

--- a/src/SlackThreads.jl
+++ b/src/SlackThreads.jl
@@ -1,9 +1,10 @@
 module SlackThreads
 
-using JSON3
-using StructTypes
 using FileIO
+using HTTP
+using JSON3
 using Mocking
+using StructTypes
 
 export AbstractSlackThread, SlackThread, slack_log_exception
 export DummyThread, SlackCallRecord

--- a/src/slack_api.jl
+++ b/src/slack_api.jl
@@ -57,10 +57,6 @@ function upload_file(local_path::AbstractString; extra_body=Dict())
         end
     end "Error when attempting to upload file to Slack"
 
-    # response = @maybecatch begin
-    #     JSON3.read(@mock readchomp(`curl -s -F file=@$(local_path) $(extra_args) -H $auth $api`))
-    # end "Error when attempting to upload file to Slack"
-
     response === nothing && return nothing
 
     if haskey(response, :ok) === true && response[:ok] != true
@@ -107,10 +103,6 @@ function send_message(thread::SlackThread, text::AbstractString; options...)
         response = @mock HTTP.post(api, headers, data_str)
         JSON3.read(response.body)
     end "Error when attempting to send message to Slack thread"
-
-    # response = @maybecatch begin
-    #     JSON3.read(@mock readchomp(`curl -s -X POST -H $auth -H 'Content-type: application/json; charset=utf-8' --data $(data_str) $api`))
-    # end "Error when attempting to send message to Slack thread"
 
     response === nothing && return nothing
     @debug "Slack responded" response

--- a/src/slack_api.jl
+++ b/src/slack_api.jl
@@ -92,11 +92,18 @@ function send_message(thread::SlackThread, text::AbstractString; options...)
     else
         @debug "Sending slack message" data api
     end
-    auth = "Authorization: Bearer $(token)"
+
+    headers = ["Authorization" => "Bearer $(token)",
+               "Content-type" => "application/json; charset=utf-8"]
 
     response = @maybecatch begin
-        JSON3.read(@mock readchomp(`curl -s -X POST -H $auth -H 'Content-type: application/json; charset=utf-8' --data $(data_str) $api`))
+        response = HTTP.request("POST", api, headers, data_str)
+        JSON3.read(response.body)
     end "Error when attempting to send message to Slack thread"
+
+    # response = @maybecatch begin
+    #     JSON3.read(@mock readchomp(`curl -s -X POST -H $auth -H 'Content-type: application/json; charset=utf-8' --data $(data_str) $api`))
+    # end "Error when attempting to send message to Slack thread"
 
     response === nothing && return nothing
     @debug "Slack responded" response

--- a/src/slack_api.jl
+++ b/src/slack_api.jl
@@ -37,7 +37,7 @@ function local_file(name, object; dir=mktempdir())
     return local_path
 end
 
-function upload_file(local_path::AbstractString; extra_args=String[])
+function upload_file(local_path::AbstractString; extra_body=Dict())
     api = "https://slack.com/api/files.upload"
 
     token = get(ENV, "SLACK_TOKEN", nothing)
@@ -48,11 +48,18 @@ function upload_file(local_path::AbstractString; extra_args=String[])
         @debug "Uploading slack file" api local_path
     end
 
-    auth = "Authorization: Bearer $(token)"
-
+    headers = ["Authorization" => "Bearer $(token)"]
     response = @maybecatch begin
-        JSON3.read(@mock readchomp(`curl -s -F file=@$(local_path) $(extra_args) -H $auth $api`))
+        open(local_path, "r") do file
+            body = HTTP.Form(vcat(collect(extra_body), ["file" => file]))
+            response = @mock HTTP.post(api, headers, body)
+            return JSON3.read(response.body)
+        end
     end "Error when attempting to upload file to Slack"
+
+    # response = @maybecatch begin
+    #     JSON3.read(@mock readchomp(`curl -s -F file=@$(local_path) $(extra_args) -H $auth $api`))
+    # end "Error when attempting to upload file to Slack"
 
     response === nothing && return nothing
 
@@ -97,7 +104,7 @@ function send_message(thread::SlackThread, text::AbstractString; options...)
                "Content-type" => "application/json; charset=utf-8"]
 
     response = @maybecatch begin
-        response = HTTP.request("POST", api, headers, data_str)
+        response = @mock HTTP.post(api, headers, data_str)
         JSON3.read(response.body)
     end "Error when attempting to send message to Slack thread"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,8 +88,6 @@ function tests_without_errors()
             @test headers == ["Authorization" => "Bearer hi",
                               "Content-type" => "application/json; charset=utf-8"]
             @test body == raw"""{"channel":"bye","thread_ts":"abc","text":"hi"}"""
-            # @test cmd ==
-            #       `curl -s -X POST -H 'Authorization: Bearer hi' -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"bye","thread_ts":"abc","text":"hi"}' https://slack.com/api/chat.postMessage`
         end
 
         Mocking.apply(hi_patch) do
@@ -103,8 +101,6 @@ function tests_without_errors()
                               "Content-type" => "application/json; charset=utf-8"]
             @test body ==
                   raw"""{"channel":"bye","thread_ts":"abc","link_names":true,"text":"hi"}"""
-            # @test cmd ==
-            #       `curl -s -X POST -H 'Authorization: Bearer hi' -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"bye","thread_ts":"abc","link_names":true,"text":"hi"}' https://slack.com/api/chat.postMessage`
         end
 
         Mocking.apply(option_patch) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,7 @@ function tests_without_errors()
 
         hi_patch = request_input_patch() do api, headers, body
             # Just a reference test; we don't really want to hit up the Slack API
-            # from CI here, so let's just check the curl query is one that works
+            # from CI here, so let's just check the HTTP.post query is one that works
             # from manual testing.
             # This could break for innocuous reasons; in that case, just update it here
             # or find a better test.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,7 +101,8 @@ function tests_without_errors()
             @test api == "https://slack.com/api/chat.postMessage"
             @test headers == ["Authorization" => "Bearer hi",
                               "Content-type" => "application/json; charset=utf-8"]
-            @test body == raw"""{"channel":"bye","thread_ts":"abc","link_names":true,"text":"hi"}"""
+            @test body ==
+                  raw"""{"channel":"bye","thread_ts":"abc","link_names":true,"text":"hi"}"""
             # @test cmd ==
             #       `curl -s -X POST -H 'Authorization: Bearer hi' -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"bye","thread_ts":"abc","link_names":true,"text":"hi"}' https://slack.com/api/chat.postMessage`
         end
@@ -112,8 +113,8 @@ function tests_without_errors()
 
         count = Ref(0)
         Mocking.apply(request_reply_patch(Dict("ok" => true, "ts" => "123",
-                                                 "file" => Dict("permalink" => "LINK")),
-                                            count)) do
+                                               "file" => Dict("permalink" => "LINK")),
+                                          count)) do
             t = SlackThread()
             @test t("bye", "file.txt" => "hi").ok == true
             # `ts` is correctly set
@@ -307,8 +308,7 @@ end
                                                      "file2.txt" => "abc")
                     end
 
-                    Mocking.apply(request_reply_patch(Dict("ok" => false,
-                                                             "error" => "no"))) do
+                    Mocking.apply(request_reply_patch(Dict("ok" => false, "error" => "no"))) do
                         @test_throws SlackThreads.SlackError("no") thread("bye")
                     end
 
@@ -362,8 +362,7 @@ end
                         @test result === nothing
                     end
 
-                    Mocking.apply(request_reply_patch(Dict("ok" => false,
-                                                             "error" => "no"))) do
+                    Mocking.apply(request_reply_patch(Dict("ok" => false, "error" => "no"))) do
                         @test (@test_logs (:error, r"Slack API") thread("bye")) === nothing
                     end
 


### PR DESCRIPTION
I think this is the best option for replacing system `curl`:
- HTTP includes support for the `Content type: multipart/form-data` format, unlike Downloads.jl
- I don't think it introduces any compat weirdness

I haven't been able to run all tests locally (running into trouble getting CairoMakie to load on 1.9) but informally I've tested this in our bots sandbox and it seems to work for
- send message
- upload single file
- post files into thread

I'm not sure if this change shoudl be breaking or not; the kwarg for `upload_files` changes, but that function isn't exported or documented...